### PR TITLE
Adds OIDC token support

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client'
   spec.add_dependency 'recursive-open-struct', '~> 1.0.0'
   spec.add_dependency 'http', '~> 2.0'
-  spec.add_dependency 'json-jwt'
 end

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client'
   spec.add_dependency 'recursive-open-struct', '~> 1.0.0'
   spec.add_dependency 'http', '~> 2.0'
+  spec.add_dependency 'json-jwt'
 end

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -9,6 +9,7 @@ require 'kubeclient/watch_stream'
 require 'kubeclient/common'
 require 'kubeclient/config'
 require 'kubeclient/missing_kind_compatibility'
+require 'kubeclient/oidc_token'
 
 module Kubeclient
   # Kubernetes Client

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -122,7 +122,7 @@ module Kubeclient
       end
 
       oidc_config = fetch_oidc_auth_config(user)
-      options.merge!(oidc_config) unless oidc_config.empty?
+      options.merge!(oidc_config)
       options
     end
 

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -120,6 +120,21 @@ module Kubeclient
           options[attr.to_sym] = user[attr] if user.key?(attr)
         end
       end
+
+      oidc_config = fetch_oidc_auth_config(user)
+      options.merge!(oidc_config) unless oidc_config.empty?
+      options
+    end
+
+    def fetch_oidc_auth_config(user)
+      options = {}
+      if user.key?('auth-provider') && user['auth-provider']['name'] == 'oidc'
+        options[:auth_provider] = 'oidc'
+        config = user['auth-provider']['config'].each_with_object({}) do |(key, value), config|
+          config[key.gsub('-', '_').to_sym] = value
+        end
+        options[:oidc_config] = config
+      end
       options
     end
   end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -37,7 +37,7 @@ module Kubeclient
     end
 
     def validate_and_retrieve_field(field)
-      discovered.key?(field) && discovered[field] or raise OidcException,
+      discovered[field] or raise OidcException,
         "OIDC discovery URL #{discovery_url} did not return a JSON document containing a '#{field}' field"
     end
   end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -1,14 +1,54 @@
 require 'json/jwt'
+require 'delegate'
 
 module Kubeclient
   OidcException = Class.new(StandardError)
 
-  class OidcToken
-    attr_reader :client_id, :refresh_token, :client_secret, :idp
+  class OidcDiscovery
+    attr_reader :idp
 
     DISCOVERY_PATH = '.well-known/openid-configuration'.freeze
-    JWKS_FIELD = 'jwks_uri'.freeze
-    TOKEN_ENDPOINT_FIELD = 'token_endpoint'.freeze
+
+    FIELD_MAP = {
+      token_endpoint: 'token_endpoint',
+      jwks_endpoint: 'jwks_uri'
+    }
+
+    class << self
+      def fields
+        FIELD_MAP.keys
+      end
+    end
+
+    FIELD_MAP.each do |method, field|
+      define_method method do
+        validate_and_retrieve_field(field)
+      end
+    end
+
+    def initialize(idp)
+      @idp = idp
+    end
+
+    private
+
+    def discovered
+      @discovered ||= JSON.parse(RestClient.get(discovery_url))
+    end
+
+    def discovery_url
+      "#{idp.chomp('/')}/#{DISCOVERY_PATH}"
+    end
+
+    def validate_and_retrieve_field(field)
+      discovered.key?(field) && discovered[field] or raise OidcException,
+        "OIDC discovery URL #{discovery_url} did not return a JSON document containing a '#{field}' field"
+    end
+  end
+
+  class OidcToken
+    attr_reader :client_id, :refresh_token, :client_secret, :idp, :oidc_discovery
+    delegate *OidcDiscovery.fields, to: :oidc_discovery
 
     REFRESH_WITHIN = 300
     ID_TOKEN = 'id_token'.freeze
@@ -21,6 +61,7 @@ module Kubeclient
       @idp = idp
       @id_token = id_token
       @refresh_token = refresh_token
+      @oidc_discovery = OidcDiscovery.new(idp)
 
       decode_token_payload(ignore_kid_not_found: true)
     end
@@ -66,27 +107,6 @@ module Kubeclient
 
     def jwks
       JSON::JWK::Set.new(JSON.parse(RestClient.get(jwks_endpoint)))
-    end
-
-    def token_endpoint
-      @token_endpoint ||= oidc_discovery_field(TOKEN_ENDPOINT_FIELD)
-    end
-
-    def jwks_endpoint
-      @jwks_endpoint ||= oidc_discovery_field(JWKS_FIELD)
-    end
-
-    def oidc_discovery
-      @oidc_discovery ||= JSON.parse(RestClient.get(oidc_discovery_url))
-    end
-
-    def oidc_discovery_field(field)
-      oidc_discovery.key?(field) && oidc_discovery[field] or raise OidcException,
-        "OIDC discovery URL #{oidc_discovery_url} did not return a JSON document containing a '#{field}' field"
-    end
-
-    def oidc_discovery_url
-      @idp_discovery_url ||= "#{idp.chomp('/')}/#{DISCOVERY_PATH}"
     end
   end
 end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -60,6 +60,7 @@ module Kubeclient
       @id_token = id_token
       @refresh_token = refresh_token
       @oidc_discovery = OidcDiscovery.new(idp_issuer_url)
+      @token_payload = decode_token_payload
     end
 
     def id_token
@@ -70,12 +71,13 @@ module Kubeclient
     private
 
     def refresh?
-      decode_token_payload[TOKEN_EXPIRY] - REFRESH_WITHIN < Time.now.to_i
+      @token_payload[TOKEN_EXPIRY] - REFRESH_WITHIN < Time.now.to_i
     end
 
     def refresh
       response = RestClient.post(token_endpoint, refresh_payload)
       @id_token = JSON.parse(response)[ID_TOKEN]
+      @token_payload = decode_token_payload
     end
 
     def refresh_payload

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -53,7 +53,7 @@ module Kubeclient
     REFRESH_WITHIN = 300
     ID_TOKEN = 'id_token'.freeze
     TOKEN_EXPIRY = 'exp'.freeze
-    GRANT_TYPE = 'refresh_token'.freeze
+    REFRESH_GRANT_TYPE = 'refresh_token'.freeze
 
     def initialize(client_id:, client_secret:, idp_issuer_url:, id_token:, refresh_token:)
       @client_id = client_id
@@ -88,7 +88,7 @@ module Kubeclient
         client_id: client_id,
         client_secret: client_secret,
         refresh_token: refresh_token,
-        grant_type: GRANT_TYPE
+        grant_type: REFRESH_GRANT_TYPE
       }
     end
 

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -1,0 +1,92 @@
+require 'json/jwt'
+
+module Kubeclient
+  OidcException = Class.new(StandardError)
+
+  class OidcToken
+    attr_reader :client_id, :refresh_token, :client_secret, :idp
+
+    DISCOVERY_PATH = '.well-known/openid-configuration'.freeze
+    JWKS_FIELD = 'jwks_uri'.freeze
+    TOKEN_ENDPOINT_FIELD = 'token_endpoint'.freeze
+
+    REFRESH_WITHIN = 300
+    ID_TOKEN = 'id_token'.freeze
+    TOKEN_EXPIRY = 'exp'.freeze
+    GRANT_TYPE = 'refresh_token'.freeze
+
+    def initialize(client_id:, client_secret:, idp:, id_token:, refresh_token:)
+      @client_id = client_id
+      @client_secret = client_secret
+      @idp = idp
+      @id_token = id_token
+      @refresh_token = refresh_token
+
+      decode_token_payload(ignore_kid_not_found: true)
+    end
+
+    def id_token
+      refresh if refresh?
+      @id_token
+    end
+
+    private
+
+    def refresh?
+      @token_payload[TOKEN_EXPIRY] - REFRESH_WITHIN < Time.now.to_i
+    end
+
+    def refresh
+      response = RestClient.post(token_endpoint, refresh_payload)
+      @id_token = JSON.parse(response)[ID_TOKEN]
+      decode_token_payload
+    end
+
+    def refresh_payload
+      {
+        client_id: client_id,
+        client_secret: client_secret,
+        refresh_token: refresh_token,
+        grant_type: GRANT_TYPE
+      }
+    end
+
+    # If the token has been expired for some time, the JWK signing key may have been rotated out
+    # Ignore KidNotFound errors IIF the token is expired and ignore_kid_not_found == true
+    def decode_token_payload(ignore_kid_not_found: false)
+      @token_payload = JSON::JWT.decode(@id_token, jwks)
+    rescue JSON::JWK::Set::KidNotFound => e
+      if ignore_kid_not_found
+        @token_payload = JSON::JWT.decode(@id_token, :skip_verification)
+        raise e unless refresh?
+      else
+        raise e
+      end
+    end
+
+    def jwks
+      JSON::JWK::Set.new(JSON.parse(RestClient.get(jwks_endpoint)))
+    end
+
+    def token_endpoint
+      @token_endpoint ||= oidc_discovery_field(TOKEN_ENDPOINT_FIELD)
+    end
+
+    def jwks_endpoint
+      @jwks_endpoint ||= oidc_discovery_field(JWKS_FIELD)
+    end
+
+    def oidc_discovery
+      @oidc_discovery ||= JSON.parse(RestClient.get(oidc_discovery_url))
+    end
+
+    def oidc_discovery_field(field)
+      oidc_discovery.key?(field) && oidc_discovery[field] or raise OidcException,
+        "OIDC discovery URL #{oidc_discovery_url} did not return a JSON document containing a '#{field}' field"
+    end
+
+    def oidc_discovery_url
+      @idp_discovery_url ||= "#{idp.chomp('/')}/#{DISCOVERY_PATH}"
+    end
+  end
+end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -47,7 +47,7 @@ module Kubeclient
   end
 
   class OidcToken
-    attr_reader :client_id, :refresh_token, :client_secret, :idp, :oidc_discovery
+    attr_reader :client_id, :refresh_token, :client_secret, :idp_provider_url, :oidc_discovery
     delegate *OidcDiscovery.fields, to: :oidc_discovery
 
     REFRESH_WITHIN = 300
@@ -55,13 +55,13 @@ module Kubeclient
     TOKEN_EXPIRY = 'exp'.freeze
     GRANT_TYPE = 'refresh_token'.freeze
 
-    def initialize(client_id:, client_secret:, idp:, id_token:, refresh_token:)
+    def initialize(client_id:, client_secret:, idp_issuer_url:, id_token:, refresh_token:)
       @client_id = client_id
       @client_secret = client_secret
-      @idp = idp
+      @idp_issuer_url = idp_issuer_url
       @id_token = id_token
       @refresh_token = refresh_token
-      @oidc_discovery = OidcDiscovery.new(idp)
+      @oidc_discovery = OidcDiscovery.new(idp_issuer_url)
 
       decode_token_payload(ignore_kid_not_found: true)
     end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -1,6 +1,3 @@
-require 'json/jwt'
-require 'delegate'
-
 module Kubeclient
   OidcException = Class.new(StandardError)
 
@@ -10,8 +7,7 @@ module Kubeclient
     DISCOVERY_PATH = '.well-known/openid-configuration'.freeze
 
     FIELD_MAP = {
-      token_endpoint: 'token_endpoint',
-      jwks_endpoint: 'jwks_uri'
+      token_endpoint: 'token_endpoint'
     }
 
     class << self
@@ -47,8 +43,10 @@ module Kubeclient
   end
 
   class OidcToken
+    extend Forwardable
+
     attr_reader :client_id, :refresh_token, :client_secret, :idp_issuer_url, :oidc_discovery
-    delegate *OidcDiscovery.fields, to: :oidc_discovery
+    def_delegators :oidc_discovery, *OidcDiscovery.fields
 
     REFRESH_WITHIN = 300
     ID_TOKEN = 'id_token'.freeze
@@ -62,8 +60,6 @@ module Kubeclient
       @id_token = id_token
       @refresh_token = refresh_token
       @oidc_discovery = OidcDiscovery.new(idp_issuer_url)
-
-      decode_token_payload(ignore_kid_not_found: true)
     end
 
     def id_token
@@ -74,13 +70,12 @@ module Kubeclient
     private
 
     def refresh?
-      @token_payload[TOKEN_EXPIRY] - REFRESH_WITHIN < Time.now.to_i
+      decode_token_payload[TOKEN_EXPIRY] - REFRESH_WITHIN < Time.now.to_i
     end
 
     def refresh
       response = RestClient.post(token_endpoint, refresh_payload)
       @id_token = JSON.parse(response)[ID_TOKEN]
-      decode_token_payload
     end
 
     def refresh_payload
@@ -92,21 +87,8 @@ module Kubeclient
       }
     end
 
-    # If the token has been expired for some time, the JWK signing key may have been rotated out
-    # Ignore KidNotFound errors IIF the token is expired and ignore_kid_not_found == true
-    def decode_token_payload(ignore_kid_not_found: false)
-      @token_payload = JSON::JWT.decode(@id_token, jwks)
-    rescue JSON::JWK::Set::KidNotFound => e
-      if ignore_kid_not_found
-        @token_payload = JSON::JWT.decode(@id_token, :skip_verification)
-        raise e unless refresh?
-      else
-        raise e
-      end
-    end
-
-    def jwks
-      JSON::JWK::Set.new(JSON.parse(RestClient.get(jwks_endpoint)))
+    def decode_token_payload
+      JSON.parse(Base64.urlsafe_decode64(@id_token.split('.')[1]))
     end
   end
 end

--- a/lib/kubeclient/oidc_token.rb
+++ b/lib/kubeclient/oidc_token.rb
@@ -47,7 +47,7 @@ module Kubeclient
   end
 
   class OidcToken
-    attr_reader :client_id, :refresh_token, :client_secret, :idp_provider_url, :oidc_discovery
+    attr_reader :client_id, :refresh_token, :client_secret, :idp_issuer_url, :oidc_discovery
     delegate *OidcDiscovery.fields, to: :oidc_discovery
 
     REFRESH_WITHIN = 300

--- a/test/config/oidcauth.kubeconfig
+++ b/test/config/oidcauth.kubeconfig
@@ -1,0 +1,26 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+    insecure-skip-tls-verify: true
+  name: localhost:8443
+contexts:
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:oidc
+  name: localhost/system:admin:oidc
+current-context: localhost/system:admin:oidc
+kind: Config
+preferences: {}
+users:
+- name: system:admin:oidc
+  user:
+    auth-provider:
+      config:
+        client-id: admin-client-id
+        client-secret: admin-client-secret
+        id-token: admin-id-token
+        idp-issuer-url: https://localhost
+        refresh-token: refresh-token
+      name: oidc

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -39,6 +39,18 @@ class KubeclientConfigTest < MiniTest::Test
     assert_equal('pAssw0rd123', context.auth_options[:password])
   end
 
+  def test_oidc_token
+    config = Kubeclient::Config.read(config_file('oidcauth.kubeconfig'))
+    context = config.context('localhost/system:admin:oidc')
+    check_context(context, ssl: false)
+    assert_equal('oidc', context.auth_options[:auth_provider])
+    assert_equal('admin-client-id', context.auth_options[:oidc_config][:client_id])
+    assert_equal('admin-client-secret', context.auth_options[:oidc_config][:client_secret])
+    assert_equal('admin-id-token', context.auth_options[:oidc_config][:id_token])
+    assert_equal('https://localhost', context.auth_options[:oidc_config][:idp_issuer_url])
+    assert_equal('refresh-token', context.auth_options[:oidc_config][:refresh_token])
+  end
+
   private
 
   def check_context(context, ssl: true)

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -436,7 +436,9 @@ class KubeclientTest < MiniTest::Test
     end
 
     assert_mock oidc_token
-    assert_requested(:get, 'http://localhost:8080/api/v1/pods', times: 1)
+    assert_requested(:get, 'http://localhost:8080/api/v1/pods', times: 1,
+      headers:  { Authorization: 'Bearer refreshed-id-token' }
+    )
   end
 
   def test_api_basic_auth_success

--- a/test/test_oidc_token.rb
+++ b/test/test_oidc_token.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class OidcTokenTest < MiniTest::Test
+  def build_jwt_jwk_pair(payload, private_key)
+    jwk = private_key.to_jwk
+    id_token = JSON::JWT.new(payload)
+    id_token.kid = jwk.thumbprint
+    id_token = id_token.sign(private_key, :RS256)
+    Struct.new(:id_token, :jwk).new(id_token.to_s, jwk)
+  end
+
+  def stub_provider(idp:, jwk_response:)
+    discovery_endpoint = "#{idp}/.well-known/openid-configuration"
+    token_endpoint = "#{idp}/token"
+    jwks_endpoint = "#{idp}/certs"
+    discovery_response_body = { issuer: idp, token_endpoint: token_endpoint, jwks_uri: jwks_endpoint }.to_json
+
+    stub_request(:get, discovery_endpoint).to_return(body: discovery_response_body, status: 200)
+    stub_request(:get, jwks_endpoint).to_return(body: jwk_response.to_json, status: 200)
+  end
+
+  def test_unexpired_token_fails_verify
+    idp = 'https://domain.tld'
+    payload = { exp: Time.now.to_i + 3600 }
+    private_key = OpenSSL::PKey::RSA.new(2048)
+    jwt = build_jwt_jwk_pair(payload, private_key)
+
+    client_id = 'client-id'
+    client_secret = 'client-secret'
+    refresh_token = 'refresh-token'
+
+    stub_provider(idp: idp, jwk_response: [{}])
+
+    assert_raises JSON::JWK::Set::KidNotFound do
+      Kubeclient::OidcToken.new(
+        client_id: client_id,
+        client_secret: client_secret,
+        idp: idp,
+        id_token: jwt.id_token,
+        refresh_token: refresh_token
+      )
+    end
+  end
+
+  def test_token_needs_refresh
+    payload = { exp: Time.now.to_i - 3600 }
+    private_key = OpenSSL::PKey::RSA.new(2048)
+    jwt = build_jwt_jwk_pair(payload, private_key)
+    id_token = jwt.id_token
+
+    client_id = 'client-id'
+    client_secret = 'client-secret'
+    refresh_token = 'refresh-token'
+
+    idp = 'https://domain.tld'
+    discovery_endpoint = "#{idp}/.well-known/openid-configuration"
+    token_endpoint = "#{idp}/token"
+    jwks_endpoint = "#{idp}/certs"
+
+    discovery_response_body = { issuer: idp, token_endpoint: token_endpoint, jwks_uri: jwks_endpoint }.to_json
+    refreshed_payload = { exp: Time.now.to_i + 3600 }
+    refreshed_token_value = build_jwt_jwk_pair(refreshed_payload, private_key).id_token
+    refresh_response_body = { token_type: 'Bearer', expires_in: 3600, id_token: refreshed_token_value }.to_json
+
+    stub_request(:get, discovery_endpoint).to_return(body: discovery_response_body, status: 200)
+    stub_request(:get, jwks_endpoint).to_return(body: [jwt.jwk].to_json, status: 200)
+    stub_request(:post, token_endpoint).to_return(body: refresh_response_body, status: 200)
+
+    oidc_token = Kubeclient::OidcToken.new(
+      client_id: client_id,
+      client_secret: client_secret,
+      idp: idp,
+      id_token: id_token,
+      refresh_token: refresh_token
+    )
+
+    assert_equal(refreshed_token_value, oidc_token.id_token)
+    assert_requested(:get, discovery_endpoint, times: 1)
+    assert_requested(:get, jwks_endpoint, times: 2)
+    assert_requested(:post, token_endpoint, times: 1,
+      body: {
+        client_id: client_id,
+        client_secret: client_secret,
+        refresh_token: refresh_token,
+        grant_type: 'refresh_token'
+      }
+    )
+  end
+
+  def test_token_no_refresh_needed
+    payload = { exp: Time.now.to_i + 3600 }
+    private_key = OpenSSL::PKey::RSA.new(2048)
+    jwt = build_jwt_jwk_pair(payload, private_key)
+
+    idp = 'https://domain.tld'
+    token_endpoint = "#{idp}/token"
+    client_id = 'client-id'
+    client_secret = 'client-secret'
+    refresh_token = 'refresh-token'
+
+    stub_provider(idp: idp, jwk_response: [jwt.jwk])
+
+    oidc_token = Kubeclient::OidcToken.new(
+      client_id: client_id,
+      client_secret: client_secret,
+      idp: idp,
+      id_token: jwt.id_token,
+      refresh_token: refresh_token
+    )
+
+    assert_equal(jwt.id_token, oidc_token.id_token)
+    assert_not_requested(:post, token_endpoint)
+  end
+end

--- a/test/test_oidc_token.rb
+++ b/test/test_oidc_token.rb
@@ -35,7 +35,7 @@ class OidcTokenTest < MiniTest::Test
       Kubeclient::OidcToken.new(
         client_id: client_id,
         client_secret: client_secret,
-        idp: idp,
+        idp_issuer_url: idp,
         id_token: jwt.id_token,
         refresh_token: refresh_token
       )
@@ -69,7 +69,7 @@ class OidcTokenTest < MiniTest::Test
     oidc_token = Kubeclient::OidcToken.new(
       client_id: client_id,
       client_secret: client_secret,
-      idp: idp,
+      idp_issuer_url: idp,
       id_token: id_token,
       refresh_token: refresh_token
     )
@@ -103,7 +103,7 @@ class OidcTokenTest < MiniTest::Test
     oidc_token = Kubeclient::OidcToken.new(
       client_id: client_id,
       client_secret: client_secret,
-      idp: idp,
+      idp_issuer_url: idp,
       id_token: jwt.id_token,
       refresh_token: refresh_token
     )

--- a/test/test_oidc_token.rb
+++ b/test/test_oidc_token.rb
@@ -29,7 +29,7 @@ class OidcTokenTest < MiniTest::Test
     client_secret = 'client-secret'
     refresh_token = 'refresh-token'
 
-    stub_provider(idp: idp, jwk_response: [{}])
+    stub_provider(idp: idp, jwk_response: { keys: [] })
 
     assert_raises JSON::JWK::Set::KidNotFound do
       Kubeclient::OidcToken.new(
@@ -63,7 +63,7 @@ class OidcTokenTest < MiniTest::Test
     refresh_response_body = { token_type: 'Bearer', expires_in: 3600, id_token: refreshed_token_value }.to_json
 
     stub_request(:get, discovery_endpoint).to_return(body: discovery_response_body, status: 200)
-    stub_request(:get, jwks_endpoint).to_return(body: [jwt.jwk].to_json, status: 200)
+    stub_request(:get, jwks_endpoint).to_return(body: { keys: [jwt.jwk] }.to_json, status: 200)
     stub_request(:post, token_endpoint).to_return(body: refresh_response_body, status: 200)
 
     oidc_token = Kubeclient::OidcToken.new(
@@ -98,7 +98,7 @@ class OidcTokenTest < MiniTest::Test
     client_secret = 'client-secret'
     refresh_token = 'refresh-token'
 
-    stub_provider(idp: idp, jwk_response: [jwt.jwk])
+    stub_provider(idp: idp, jwk_response: { keys: [jwt.jwk] })
 
     oidc_token = Kubeclient::OidcToken.new(
       client_id: client_id,


### PR DESCRIPTION
Adds support for OIDC tokens.
- no token client-side validation is performed, it's the responsibility of the Kubernetes controller to validate any tokens passed to it
- inspects token expiry time and attempts to refresh when necessary

There is minimal error handling.  The JWT spec is quite strict, so any exceptions are likely unrecoverable and should crash the process.